### PR TITLE
Fix paper URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## SPM_toolkit
-This repository contains code and data used in the following [paper](https://arxiv.org/abs/1805.08297):
+This repository contains code and data used in the following [paper](https://arxiv.org/abs/1806.04330):
 
 	@inproceedings{lan2018toolkit,
 	  author     = {Lan, Wuwei and Xu, Wei},


### PR DESCRIPTION
Current URL in readme.md points to wrong paper. I have changed to the correct paper.